### PR TITLE
Allow new versions (beyond 2.0) of USB serial interfaces.

### DIFF
--- a/ohbot/ohbot.py
+++ b/ohbot/ohbot.py
@@ -458,7 +458,7 @@ def checkPort(p):
         line = ser.readline()
         ser.close()
 
-        subString = "v1".encode('latin-1')
+        subString = "v".encode('latin-1')
 
         if line.find(subString) != -1:
             return True


### PR DESCRIPTION
Currently, the USB serial version test fails on my Mac Book M2 with OSX 14.3 Sonoma.

Output:
```
Checked /dev/cu.usbmodem2101 Ohbot not connected
Ohbot not found
```

In function `checkPort(p)`, line `line = ser.readline()` returns:
```
>>> line
b'SVer:v2.9.16 ,1\r\n'
```